### PR TITLE
[iOS] AirMapMarker should query self.reactSubviews instead of self.subviews

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -198,7 +198,7 @@
 
 - (BOOL)shouldUsePinView
 {
-    return self.subviews.count == 0 && !self.imageSrc;
+    return self.reactSubviews.count == 0 && !self.imageSrc;
 }
 
 - (void)setImageSrc:(NSString *)imageSrc


### PR DESCRIPTION
AirMapMarker should query self.reactSubviews instead of self.subviews 

Fixes https://github.com/lelandrichardson/react-native-maps/issues/364
